### PR TITLE
fix: Problems with sub-hourly timesteps

### DIFF
--- a/doc/md/CHANGELOG.md
+++ b/doc/md/CHANGELOG.md
@@ -38,6 +38,7 @@ The v6.0.0 changes listed below are abbreviated. For specific details refer to t
 * **Unsaturated Zone Water Balance:** Fixed several mass-balance errors in `tHydroModel::UnSaturatedZone` that created or destroyed small amounts of water. Evapotranspiration is now supply-limited before it is committed so reported ET cannot exceed the water deliverable above the water table pinned at bedrock (`tHydroModel::MaxSoilETRate`); the `WTStaysAtSurf` and `WTGetsToSurf` surface-runoff partitions now conserve net influx when net rainfall is negative under lateral inflow; and the `Perched_Evol` wedge collapse conserves column moisture instead of resetting it to a fixed value. ([#125](https://github.com/tRIBS-Model/tRIBS/pull/125))
 * **Snow Pack Mass Balance:** Corrected a sign error in `tSnowPack` where, when evaporation or sublimation demand exceeded the remaining liquid or ice store, the loss was recorded with the wrong sign, producing a mass-balance error as the pack disappeared. ([#125](https://github.com/tRIBS-Model/tRIBS/pull/125))
 * **Channel Transmission Loss Reporting:** Fixed a unit mismatch that truncated the transient channel-conductivity period to zero under sub-hourly timesteps, and corrected the MRF `ChannelPerc` output, which booked the full Darcy loss rate off negligible flow depths and accumulated it with a hardcoded timestep. Reported losses are now capped at the water available to each stream node and integrated over the routing timestep; the routing solver itself is unchanged. ([#125](https://github.com/tRIBS-Model/tRIBS/pull/125))
+* **Sub-hourly Forcing:** The original formulation of the snow module was not written to allow any input other than an hourly timestep with hourly forcing data. This has been fixed. Additionally, there were multiple problems with the output accumulators when using sub-hourly forcing that were corrected.
 
 ### Changed & Refactored
 * **Input Simplification:** Streamlined the `.in` file by removing legacy or unused options including:
@@ -102,7 +103,7 @@ The v6.0.0 changes listed below are abbreviated. For specific details refer to t
 ### Changed & Refactored
 * **Output Standard:** Modified writing of soil water state variables in pixel, dynamic, and MRF files to convert from sloped state variables to vertical depths.
 * **Solar Radiation:** Centralized slope, albedo, and vegetation corrections into `inShortWave()`, reducing redundancy and improving consistency across the energy balance module. ([#84](https://github.com/tRIBS-Model/tRIBS/pull/84))
-* **ET Partitioning:** Updated `tEvapoTrans` to prioritize potential evaporation partitioning: first to wet canopy, then transpiration, and lastly soil evaporation.
+* **ET Partitioning:** Updated `tEvapoTrans` to prioritize potential evaporation partitioning: first to wet canopy, and then transpiration. Soil evaporation is separate and uses the full potential ET rate in its calculation.
 * **Snow Physics Refactor:** ([#84](https://github.com/tRIBS-Model/tRIBS/pull/84))
     * Updated albedo decay function with a minimum albedo threshold.
     * Refactored latent and sensible heat flux for ground snowpack to prevent temperatures from dropping below zero when liquid water is present.

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -1173,7 +1173,7 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 			int snowActive = 0;
 			if (snowOption) {
 				double snWE = cNode->getLiqWE() + cNode->getIceWE();
-				if ((snWE > 1e-3) || (cNode->getLiqRouted() > 0.0))
+				if ((snWE > 1e-4) || (cNode->getLiqRouted() > 0.0))
 					snowActive = 1;
 			}
 

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -1176,7 +1176,14 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 				if ((snWE > 1e-3) || (cNode->getLiqRouted() > 0.0))
 					snowActive = 1;
 			}
-			double soilDemand = snowActive ? evapDryCanopy : (evapSoil + evapDryCanopy);
+
+			// With snow on the ground there is no bare-soil evaporation:
+			// UnSaturatedZone never extracts it (see Ractual above) and
+			// callSnowPack zeroes the node's EvapSoil after this function. CJC2026
+			if (snowActive)
+				evapSoil = 0.0;
+
+			double soilDemand = evapSoil + evapDryCanopy;
 			if (soilDemand > 0.0) {
 				// The committed rate is extracted every unsaturated step until
 				// the next ET call, so the supply window is the ET interval,
@@ -1187,8 +1194,7 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 				if (soilDemand > maxSoilET) {
 					double scale = maxSoilET/soilDemand;
 					evapDryCanopy *= scale;
-					if (!snowActive)
-						evapSoil *= scale;
+					evapSoil *= scale;
 				}
 			}
 		}
@@ -1200,8 +1206,12 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 		cNode->setEvapDryCanopy(evapDryCanopy);
 		cNode->setEvapSoil(evapSoil);
 		cNode->setEvapoTrans(evapoTranspiration);
-		cNode->addTotEvap(evapoTranspiration); // add to cumulative totals CJC2020
-		cNode->addBarEvap(evapSoil); // add to cumulative totals CJC2020
+		// Cumulative depths (mm) for the integrated output's cET and cEsoil.
+		// evapoTranspiration and evapSoil are rates in mm/hr held constant
+		// until the next ET call, so the depth added over this interval is
+		// rate*ETISTEP. CJC2026
+		cNode->addTotEvap(evapoTranspiration * (timer->getEtIStep())); // cumulative totals CJC2020
+		cNode->addBarEvap(evapSoil * (timer->getEtIStep())); // cumulative totals CJC2020
 		
 		// Update average ET rate from an element
 		auto te = (double)timer->getElapsedETISteps(timer->getCurrentTime());
@@ -2937,7 +2947,9 @@ void tEvapoTrans::setToNode(tCNode* cNode)
 	cNode->setAirPressure(atmPressC);
 	cNode->setSkyCover(skyCoverC);
 	cNode->setWindSpeed(windSpeedC);
-	cNode->addCumHrsSun(SunHour);
+	// SunHour is a 0/1 flag per ET step, so accumulating it raw counted steps
+	// rather than hours. CJC2026
+	cNode->addCumHrsSun(SunHour * timer->getEtIStep());
 
 	// Elapsed MET steps from the beginning
 	auto te = (double)timer->getElapsedMETSteps(timer->getCurrentTime());
@@ -2953,7 +2965,12 @@ void tEvapoTrans::setToNode(tCNode* cNode)
 
 	cNode->setSheltFact(shelterFactorGlobal);
 	cNode->setLandFact(landRefGlobal);	
-	cNode->addRSin(inShortR*3600.0); }
+	// Incoming shortwave energy over this ET step in kJ/m2: inShortR is W/m2,
+	// x seconds gives J/m2, /1000 gives kJ/m2. This must match the units of
+	// tSnowPack::setToNodeSnP's addRSin(RSin*timeSteps), whose RSin is already
+	// in kW/m2 (naughttokilo): with OPTSNOW=1 both paths feed the same
+	// cumulative (this one on snow-free steps). CJC2026
+	cNode->addRSin(inShortR * timer->getEtIStep() * 3600.0 / 1000.0); }
 
 //=========================================================================
 //
@@ -3235,7 +3252,11 @@ void tEvapoTrans::readHydroMetData(int num)
 			SurfTemperature[count] = (fabs(tempo - 9999.99) > 1.0E-3 && (tempo < -60 || tempo > 70)) ? 9999.99 : tempo;
 
 
-			if (count > 0) {
+			// Timestamp continuity check. Skipped for sub-hourly METSTEP: the
+			// data format only carries integer hours, and the supported
+			// convention for sub-hourly forcing is duplicated hourly rows.
+			//  Mirrors the rainDt >= 1.0 guard in tRainfall::readRainData. CJC2026
+			if (count > 0 && timer->getMetStep() >= 1.0) {
 				int expected_yr = yr[count-1];
 				int expected_mo = mo[count-1];
 				int expected_dy = dy[count-1];

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -906,7 +906,11 @@ void tHydroModel::UnSaturatedZone(double dt)
 			routeWE = cn->getLiqRouted();
 			if ((snWE > 1e-3) || (routeWE > 0.)) {
                 //WR 12182023 removed EvapVeg from route water following above approach and because transpiration can still occur w/snow
-				Ractual = 10.0*routeWE-EvapVeg; //have to convert to mm // Changed from R to Ractual CJC2020
+				// routeWE is the melt DEPTH released over this snow/ET step [cm],
+				// so 10*routeWE is the melt in mm delivered over ETISTEP hours.
+				// Ractual is a rate [mm hr^-1], multiplied by dt, so the depth 
+				// has to be divided by the step length. CJC2026
+				Ractual = 10.0*routeWE/timer->getEtIStep() - EvapVeg; // Changed from R to Ractual CJC2020
 			}
 		}
 

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -1189,8 +1189,8 @@ void tSnowPack::setToNodeSnP(tCNode *node) {
     node->setSnTempC(snTempC);
     node->setCrustAge(crustAge);
     node->setEvapoTransAge(ETAge);
-    node->setSnSub(snSub); // scaled by non-vegetated area
-    node->setSnEvap(snEvap); // scaled by non-vegetated area
+    node->setSnSub(snSub);
+    node->setSnEvap(snEvap);
 
     //mass flux
     node->setLiqRouted(liqRoute);
@@ -1722,9 +1722,11 @@ double tSnowPack::resFactCalc() {
     // https://doi.org/10.1029/2008WR007042
 
     // Bulk Richardson Number (Eq. 17)
-    // Use windSpeedS (attenuated wind at snow surface) in RiB calc.
-    // Though Ta is from 2m AGL, we prioritize the snow–air interface.
-    // This matches the aerodynamic resistance formulation and maintains internal consistency.
+    // Evaluated with windSpeedC, the reference-level wind, so that the wind and
+    // the air temperature Ta both refer to the same 2 m reference height.
+    // An earlier version used windSpeedS (the canopy-attenuated wind at the snow
+    // surface); note ra itself still blends ras(windSpeedS) and rav(windSpeedC),
+    // so RiB matches the rav term rather than the blend. CJC2026
     double RiB = (g * zm_eff * (Ta - Ts)) / (T_avg * windSpeedC* windSpeedC);
 
     // Compute upper limit Ri_u (Eq. 24)
@@ -1746,8 +1748,11 @@ double tSnowPack::resFactCalc() {
     }
 
 	// Clamp the stability correction factor to a reasonable range
-	// As RiB approaches Ri_cr, C_stab approaches infinity, so we limit it
-	if (C_stab > 15.0) { C_stab = 15.0; } // kaero can at most be 15 times the original value
+	// As RiB approaches Ri_cr, C_stab approaches infinity, so we limit it.
+	// The cap only binds in stable conditions (C_stab > 1, i.e. ra inflated);
+	// since ra *= C_stab and kaero = 1/ra, it keeps kaero from falling below
+	// 1/15 of its uncorrected value. CJC2026
+	if (C_stab > 15.0) { C_stab = 15.0; }
 
     // Apply correction to aerodynamic resistance
     ra *= C_stab;

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -990,7 +990,6 @@ void tSnowPack::callSnowIntercept(tCNode *node, tIntercept *interceptModel, int 
         // arriving this timestep, and the intercepted mass must be converted
         // back to a rate when debited from throughfall (netPrecipitation is
         // consumed as mm/hr downstream). CJC2026
-        double precipStep = precip * timeSteph; // precip depth this step (kg/m^2)
         Isnow = 0.7 * (Imax - Iold) * (1 - exp(-(precip * timeSteph) / Imax));
         I = Iold + Isnow;
 

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -547,8 +547,11 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
                 cNode->setNetPrecipitation(rain);
             }
 
-            precip = cNode->getNetPrecipitation(); //units in mm
-            precip += snUnload * ctom; // units in mm
+            precip = cNode->getNetPrecipitation(); //units in mm/hr
+            // snUnload is the canopy snow unloaded over this step [cm], a depth,
+            // while precip is a rate [mm/hr] that the mass updates below turn
+            // back into a depth via *timeSteps/3600. CJC2026
+            precip += snUnload * ctom / timeSteph; // cm/step -> mm/hr
 
             //change mass (volume) quantities to correct units (kJ, m, C, s)
             iceWE = iceWE * cmtonaught; // mm to m
@@ -564,9 +567,10 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
             // in order to calculate the new snow depth.
 
             // Calculate Incoming Mass (temporary variables)
-            // precip is in mm. Convert to meters (0.001).
-            double newSnowM = (precip * snowFracCalc()) * 0.001; 
-            double newRainM = (precip * (1.0 - snowFracCalc())) * 0.001;
+            // precip is a rate in mm/hr, so scale by the timestep (hr) to get
+            // the depth arriving this step, then convert mm to m (0.001). CJC2026
+            double newSnowM = (precip * snowFracCalc()) * timeSteph * 0.001;
+            double newRainM = (precip * (1.0 - snowFracCalc())) * timeSteph * 0.001;
 
             // Calculate projected Mass States
             // Approximation of what the pack will look like after this timestep.
@@ -693,7 +697,10 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
                 phfOnOff = 1.0;
 
                 //reset crust age if snowing out
-                if (precip * snowFracCalc() > albResetThresh) {
+                // albResetThresh is a depth (mm) but precip is a rate (mm/hr),
+                // so scale by the timestep (hr) to compare fresh-snow depth this
+                // step against the threshold. CJC2026
+                if (precip * snowFracCalc() * timeSteph > albResetThresh) {
                     crustAge = 0.0;
                 }
 
@@ -978,11 +985,17 @@ void tSnowPack::callSnowIntercept(tCNode *node, tIntercept *interceptModel, int 
         Imax = 4.4 * LAI;
 
         //compute new intercepted snow (kg/m^2)
-        Isnow = 0.7 * (Imax - Iold) * (1 - exp(-precip / Imax));
+        // precip is a rate (mm/hr == kg/m^2/hr) while the canopy load I is a
+        // mass (kg/m^2), so the interception update must use the precip depth
+        // arriving this timestep, and the intercepted mass must be converted
+        // back to a rate when debited from throughfall (netPrecipitation is
+        // consumed as mm/hr downstream). CJC2026
+        double precipStep = precip * timeSteph; // precip depth this step (kg/m^2)
+        Isnow = 0.7 * (Imax - Iold) * (1 - exp(-(precip * timeSteph) / Imax));
         I = Iold + Isnow;
 
-        //precip minus intercepted snow (i.e. throughfall)
-        throughfall = precip - Isnow;
+        //precip minus intercepted snow (i.e. throughfall), kept as a rate (mm/hr)
+        throughfall = precip - Isnow / timeSteph;
 
         //if there was old snow, sublimate and unload
         if (Iold > 0.0 && flag) {
@@ -1244,7 +1257,9 @@ void tSnowPack::setToNodeSnP(tCNode *node) {
     node->addRLout(RLout * timeSteps);
     node->addRSin(RSin * timeSteps);
     node->addCumUerror(Uerr * timeSteps);
-    node->addCumHrsSnow(snOnOff);
+    // snOnOff is a 0/1 flag per ET step, so accumulating it raw counted steps
+    // rather than hours. Originally: addCumHrsSnow(snOnOff). CJC2026
+    node->addCumHrsSnow(snOnOff * timer->getEtIStep());
 
     //reset fluxes to zero
     L = H = Prec = G = RLin = RLout = RSin = dUint = 0.0;
@@ -1573,8 +1588,12 @@ double tSnowPack::precipitationHFCalc() {
     double frac;
 
     //  frac = snowFracCalc();
-    snPrec = (snowFracCalc() * (rain + ctom * snUnload)) * mtoc; //convert from mm to cm
-    liqPrec = ((1 - snowFracCalc()) * (rain + ctom * snUnload)) * mtoc; //convert from mm to cm
+    // snUnload is the canopy snow unloaded over this step [cm], a depth, while
+    // rain is a rate [mm/hr] and the /3600 below treats the sum as a per-hour
+    // depth, so the unloaded snow has to be expressed as a rate as well. CJC2026
+    double unloadRate = ctom * snUnload / timeSteph; // cm/step to mm/hr
+    snPrec = (snowFracCalc() * (rain + unloadRate)) * mtoc; //convert from mm to cm
+    liqPrec = ((1 - snowFracCalc()) * (rain + unloadRate)) * mtoc; //convert from mm to cm
 
     if (airTemp > 0) {
         // snPrec term is zero (ice assumed to be at 0C on arrival)

--- a/src/tHydro/tWaterBalance.cpp
+++ b/src/tHydro/tWaterBalance.cpp
@@ -51,7 +51,15 @@ void tWaterBalance::SetWaterBalance(tInputFile &infile)
 	metStep = infile.ReadItem(metStep, "METSTEP");
 	unsStep = infile.ReadItem(unsStep, "TIMESTEP");
 	satStep = infile.ReadItem(satStep, "GWSTEP");
-	
+
+	// Snow/ET step in hours, mirroring tRunTimer's etistep = min(METSTEP,
+	// RAININTRVL). Read here rather than taken from the timer because this
+	// class already sources its other steps straight from the input file.
+	// Used to convert the per-step melt depth carried on the node into a rate. CJC2026
+	double dtRain = 0.0;
+	dtRain = infile.ReadItem(dtRain, "RAININTRVL"); // hours
+	etiStep = (dtRain >= metStep/60.0) ? metStep/60.0 : dtRain;
+
 	return;
 }
 
@@ -181,7 +189,9 @@ void tWaterBalance::UnSaturatedBalance()
 		Run = cNode->getSrf()/unsStep;
 		A = cNode->getVArea();
 		Inf = cNode->getNetPrecipitation();
-        Melt = cNode->getLiqRouted()*10.0;//WR 12192023: to mm, but implicitly mm/hr as thats total amount melted in 1 hr
+        // getLiqRouted() is the melt DEPTH released over the snow/ET step [cm];
+        // dividing by the step length gives the rate. CJC2026
+        Melt = cNode->getLiqRouted()*10.0/etiStep;
 
         if(cNode->getLiqWE() + cNode->getIceWE() > 1e-4){
             Inf = Melt; //WR 12192023: snow on the ground Inf set to Melt

--- a/src/tHydro/tWaterBalance.h
+++ b/src/tHydro/tWaterBalance.h
@@ -59,6 +59,7 @@ protected:
 
   int finalTime;
   double metStep, unsStep, satStep; //WR 12192023: rounding errors converting from double in .in to int here
+  double etiStep;                   // Snow/ET step [hr]; see SetWaterBalance
   double *BasinStorages;
 };
 

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -493,7 +493,7 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				<<"PotEvp_mm_h,"
 				<<"EvpTtrs_mm_h,"      //34
 				<<"EvpWetCan_mm_h,"
-				<<"EvpDryCan_mm_h,"
+				<<"TransDryCan_mm_h,"
 				<<"EvpSoil_mm_h,"
 				<<"Gflux_W_m2,"
 				<<"HFlux_W_m2,"        //39
@@ -1567,6 +1567,7 @@ void tCOutput<tSubNode>::BuildDynVarTable(const std::set<std::string> &selection
 		{"SoilMoist",    3, [](tSubNode *cn) { return cn->getSoilMoistureSC(); }},
 		{"RootMoist",    3, [](tSubNode *cn) { return cn->getRootMoistureSC(); }},
 		{"CanStorage",   3, [](tSubNode *cn) { return cn->getCanStorage(); }},
+		{"TransDryCan",  5, [](tSubNode *cn) { return cn->getEvapDryCanopy(); }},
 		{"EvpSoil",      5, [](tSubNode *cn) { return cn->getEvapSoil(); }},
 		{"ET",           5, [](tSubNode *cn) { return cn->getEvapoTrans(); }},
 		{"GFlux",        3, [](tSubNode *cn) { return cn->getGFlux(); }},


### PR DESCRIPTION
Fixes unit errors that only appear under sub-hourly forcing (`METSTEP` or `RAININTRVL` below 60 min), plus the cumulative-output and validation issues that accompany them, targeting the upcoming v6.0.0 release.

## Root Cause

Several node variables carry a per-step depth while their consumers treat them as an hourly rate. The two are numerically the same at `ETISTEP = 1 hr`, so the snow module never exposed the mismatch as the module was hardcoded to an hourly timestep. For example, at 15 min only a quarter of the quantity survives. Three main instances:

* **Snowmelt into the soil column** (`tHydroModel::UnSaturatedZone`, `tWaterBalance::UnSaturatedBalance`): `getLiqRouted()` is a per-step depth assigned to `Ractual` / `Melt`, which are rates.
* **Canopy unloading into the pack, mass** (`tSnowPack::callSnowPack`): `snUnload` [cm/step] added to `precip` [mm/hr].
* **Canopy unloading into the pack, energy** (`tSnowPack::precipitationHFCalc`): same mix in `rain + ctom*snUnload`.

Additional fixes

* `addTotEvap` / `addBarEvap` / `addCumHrsSun` / `addCumHrsSnow` summed rates and 0/1 flags as though each step were an hour.
* `cRSIn` mixed J and kJ *within a single run*, the ET path wrote J m⁻², `setToNodeSnP` writes kJ m⁻², and with `OPTSNOW = 1` both feed the same accumulator.
* Density projection, albedo-reset threshold and canopy interception load all treated `precip` (mm/hr) as a per-step depth.
* `cEsoil` / `cET` credited bare-soil evaporation under snow that `UnSaturatedZone` never extracts. The instantaneous value was zeroed only *after* accumulation. 
* Sub-hourly station forcing was rejected by the MDF timestamp check, it now skips below an hourly step, mirroring the rain-gauge reader's guard.
* `EvpDryCan_mm_h` renamed to `TransDryCan_mm_h`, and `TransDryCan`.

## Validation

Using the Happy Jack, the hourly forcing was duplicated into 15-minute and 30-minute records for separate tests. These forcings were tested along with a mix of sub-hourly precipitation and hourly meteorological forcing, and vice versa. No problems with the water balance were found.