### PR TITLE
feat: Add executable workflow

### DIFF
--- a/.github/workflows/release_binaries.yml
+++ b/.github/workflows/release_binaries.yml
@@ -95,7 +95,7 @@ jobs:
 
       # CPACK_PACKAGE_FILE_NAME is the full project title with spaces and carries no
       # platform, which is why past releases were renamed by hand before upload.
-      - name: Rename asset and generate checksum
+      - name: Rename asset
         id: asset
         run: |
           version="${{ steps.release.outputs.version }}"
@@ -103,12 +103,6 @@ jobs:
           name="tRIBS-${version}-${{ matrix.asset_suffix }}.sh"
           mkdir -p dist
           mv "$src" "dist/${name}"
-          cd dist
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum "$name" > "${name}.sha256"
-          else
-            shasum -a 256 "$name" > "${name}.sha256"
-          fi
           echo "name=${name}" >> "$GITHUB_OUTPUT"
 
       # Extract the installer and run the binary the way a user would, to catch a
@@ -137,6 +131,5 @@ jobs:
         run: >
           gh release upload "${{ steps.release.outputs.tag }}"
           "dist/${{ steps.asset.outputs.name }}"
-          "dist/${{ steps.asset.outputs.name }}.sha256"
           --repo "${{ github.repository }}"
           --clobber

--- a/.github/workflows/release_binaries.yml
+++ b/.github/workflows/release_binaries.yml
@@ -1,0 +1,142 @@
+name: release_binaries
+run-name: Attaching tRIBS binaries to ${{ github.event.release.tag_name || inputs.tag }}
+
+# Builds the serial tRIBS executable on each supported platform, packages it with
+# CPack, smoke-tests the resulting installer, and attaches it to the GitHub release.
+#
+# Only the serial executable is published. tRIBSpar links dynamically against the
+# runner's Open MPI (Homebrew on macOS, apt on Linux) and will not load on a machine
+# without that exact runtime at that exact prefix, so shipping it is misleading.
+# Anyone running MPI is compiling from source anyway.
+
+on:
+  release:
+    types: [published]
+  # Manual entry point, for re-running a failed upload or backfilling an older tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build and attach binaries to (e.g. v6.0.0)"
+        required: true
+        type: string
+
+# Required for `gh release upload`. The default token is read-only on newer repos.
+permissions:
+  contents: write
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ubuntu-22.04 rather than ubuntu-latest: the binary carries a glibc floor
+          # from whatever built it, and 22.04 (glibc 2.35) covers far more of the HPC
+          # systems tRIBS users run on than 24.04 (glibc 2.39) does.
+          - runner: ubuntu-22.04
+            os_label: Linux
+            package_dir: packaging/Linux
+            asset_suffix: Linux
+            extra_cmake_args: ""
+          - runner: macos-14
+            os_label: macOS/Silicon
+            package_dir: packaging/macOS/Silicon
+            asset_suffix: macOS-Silicon
+            extra_cmake_args: "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0"
+          - runner: macos-15-intel
+            os_label: macOS/Intel
+            package_dir: packaging/macOS/Intel
+            asset_suffix: macOS-Intel
+            # 10.15 is safe: the code base uses no std::filesystem, which is the only
+            # C++17 feature that would raise the floor.
+            extra_cmake_args: "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15"
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Resolve release tag
+        id: release
+        run: |
+          tag="${{ github.event.release.tag_name || inputs.tag }}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository at the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+
+      # The version is hardcoded in CMakeLists.txt, so it can drift from the tag.
+      # Fail here rather than publishing an asset whose name lies about its contents.
+      - name: Verify tag matches TRIBS_VERSION
+        run: |
+          cmake_version=$(sed -n 's/^set(TRIBS_VERSION \([0-9.]*\))/\1/p' CMakeLists.txt)
+          if [ "${{ steps.release.outputs.version }}" != "$cmake_version" ]; then
+            echo "::error::Release tag ${{ steps.release.outputs.version }} does not match TRIBS_VERSION $cmake_version in CMakeLists.txt"
+            exit 1
+          fi
+
+      - name: Configure serial build
+        run: >
+          cmake -S . -B cmake-build-serial
+          -DCMAKE_BUILD_TYPE=Release
+          -Dparallel=OFF
+          -Dpackaging=ON
+          -Dos='${{ matrix.os_label }}'
+          ${{ matrix.extra_cmake_args }}
+
+      - name: Build
+        run: cmake --build cmake-build-serial --target all
+
+      # Serial-only, so the multi-config file in packaging/utilities is bypassed in
+      # favour of the config CMake generated for this build directory.
+      - name: Package with CPack
+        run: cpack --config cmake-build-serial/CPackConfig.cmake
+
+      # CPACK_PACKAGE_FILE_NAME is the full project title with spaces and carries no
+      # platform, which is why past releases were renamed by hand before upload.
+      - name: Rename asset and generate checksum
+        id: asset
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          src="${{ matrix.package_dir }}/TIN-based Real-time Integrated Basin Simulator-${version}.sh"
+          name="tRIBS-${version}-${{ matrix.asset_suffix }}.sh"
+          mkdir -p dist
+          mv "$src" "dist/${name}"
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$name" > "${name}.sha256"
+          else
+            shasum -a 256 "$name" > "${name}.sha256"
+          fi
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+
+      # Extract the installer and run the binary the way a user would, to catch a
+      # package that builds but cannot load its shared libraries.
+      - name: Smoke-test the packaged installer
+        run: |
+          # --exclude-subdir skips the header's own mkdir, so create the prefix first.
+          mkdir -p smoketest
+          ./dist/${{ steps.asset.outputs.name }} --skip-license --exclude-subdir --prefix="${PWD}/smoketest"
+          binary=$(find smoketest -type f -name tRIBS | head -n 1)
+          if [ -z "$binary" ]; then
+            echo "::error::No tRIBS executable found in the extracted package"
+            exit 1
+          fi
+          # No arguments prints usage and exits 1, so a clean load is exit 1 + usage text.
+          output=$("$binary" 2>&1) && status=0 || status=$?
+          echo "$output"
+          if [ "$status" -ne 1 ] || ! printf '%s' "$output" | grep -q "Usage:"; then
+            echo "::error::Packaged tRIBS did not run (exit ${status})"
+            exit 1
+          fi
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh release upload "${{ steps.release.outputs.tag }}"
+          "dist/${{ steps.asset.outputs.name }}"
+          "dist/${{ steps.asset.outputs.name }}.sha256"
+          --repo "${{ github.repository }}"
+          --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__
 /testing/black_box/happy_jack_pytest/happy_jack/
 .vscode
 CMakePresets.json
+# CPack output from -Dpackaging=ON
+packaging/Linux/
+packaging/macOS/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.06747/status.svg)](https://doi.org/10.21105/joss.06747)
 
 # TIN-based Real-time Integrated Basin Simulator: Version 6.0.0
-This repository contains source code for the fully distributed hydrological model: TIN-based Real-time Integrated Basin Simulator (tRIBS). We provide extensive documention of the model [here](https://tribshms.readthedocs.io/en/latest/). Our documentation also contains useful information about working with the tRIBS code base through [GitHub](https://tribshms.readthedocs.io/en/latest/man/Using%20GitHub.html) and how to [contribute](https://tribshms.readthedocs.io/en/latest/man/Contributing.html). Finally we also provide [templates](https://tribshms.readthedocs.io/en/latest/man/Templates.html) and [benchmarks](https://tribshms.readthedocs.io/en/latest/man/Benchmarks.html) with instruction on how to utilize these resources in the documentation. 
+This repository contains source code for the fully distributed hydrological model: TIN-based Real-time Integrated Basin Simulator (tRIBS). We provide extensive documentation of the model [here](https://tribshms.readthedocs.io/en/latest/). Our documentation also contains useful information about working with the tRIBS code base through [GitHub](https://tribshms.readthedocs.io/en/latest/man/Using%20GitHub.html) and how to [contribute](https://tribshms.readthedocs.io/en/latest/man/Contributing.html). Finally we also provide [templates](https://tribshms.readthedocs.io/en/latest/man/Templates.html).
 
 Licensing information can be found in [LICENSE.txt](./LICENSE.txt).
 
@@ -17,11 +17,19 @@ Release notes are provided [here](https://tribshms.readthedocs.io/en/latest/man/
 Model reference list, number of citations and H-index can be found [here](https://csdms.colorado.edu/wiki/Model:TIN-based_Real-time_Integrated_Basin_Simulator_(tRIBS)).
 
 ## Installation 
-We provide three options for accessing the tRIBS model:
+We provide four options for accessing the tRIBS model:
 
 1) Compiled executables for latest [macOS and Ubuntu](https://tribshms.readthedocs.io/en/latest/man/Executables.html#executables) systems
 2) [Docker](https://tribshms.readthedocs.io/en/latest/man/Docker.html)
 3) [CMake build system](https://tribshms.readthedocs.io/en/latest/man/Model_Execution.html#cmake)
+4) [Codespaces](https://github.com/tRIBS-Model/tRIBS-Workshop-Sandbox)
+
+## Getting Started
+We have prepared multiple example applications for users to apply and learn from:
+
+1) [Benchmarks](https://github.com/tRIBS-Model/tRIBS-benchmarks): Two fully setup models that users can run themselves or explore various model inputs. Requires users to supply their own installation of the model.
+2) [Codespaces](https://github.com/tRIBS-Model/tRIBS-Workshop-Sandbox): An example application of generating and input file and running the model in a cloud computing environment, free of charge. Requires nothing from the user other than a Github account and a web-browser.
+3) [pytRIBS Examples](https://github.com/tRIBS-Model/pytRIBS-examples): Example applications of full model generation in a Jupyter notebook using the pytRIBS python package. Requires the users to have pytRIBS installed in a python environment and Docker installed.
 
 ## Release/Version Notes
 tRIBS uses semantic versioning. We record updates of major, minor, and patch versions [here](./doc/md/CHANGELOG.md).


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and attaches the tRIBS binaries to a release automatically when it is published. Previously these were compiled and uploaded by hand.

Builds on three runners: Linux (Ubuntu 22.04), macOS Intel, and macOS Apple Silicon. Only the serial tRIBS executable is published because parallel tRIBS links dynamically against the user's MPI version and would not load on their machine properly.